### PR TITLE
Expand warranty docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,14 @@ uv run simple-math-cli
 
 You will be prompted to enter arithmetic questions, and the program will answer them using DSPy and OpenAI.
 
+### Run the `doc_qa` example
+
+```sh
+uv run doc-qa-cli
+```
+
+This CLI automatically loads sample warranty documents for Acme Homes and lets you ask questions or generate summaries.
+
 ## Contributing More Examples
 
 - Add a new directory (e.g., `my_example/`) with an `__init__.py` and your code.

--- a/doc_qa/__init__.py
+++ b/doc_qa/__init__.py
@@ -1,0 +1,1 @@
+"""Document QA and summarization example."""

--- a/doc_qa/docs/10_duration_limits.txt
+++ b/doc_qa/docs/10_duration_limits.txt
@@ -1,0 +1,11 @@
+Warranty Duration Limits
+1. Workmanship and material defects are covered for one year from the closing date, giving homeowners time to identify and report initial issues.
+2. Mechanical systems such as HVAC, electrical, and plumbing have a two-year warranty that protects against installation errors or major component failures.
+3. Structural components including the foundation, load-bearing walls, and roof framing are warranted for a full ten years against catastrophic failure.
+4. Roof shingles or tiles have a one-year workmanship warranty, but additional manufacturer coverage may extend for twenty or more years, depending on the product.
+5. Windows and exterior doors carry a two-year warranty for operational functionality and sealing, ensuring they open, close, and lock properly without drafts.
+6. Appliances provided by Acme Homes come with one-year service coverage, after which the manufacturer warranty remains in effect for the specified duration.
+7. Waterproofing measures in basements and crawl spaces are covered against leaks for two years, provided the homeowner maintains proper drainage away from the structure.
+8. Concrete slabs and driveways are warranted against severe cracking and settling for one year, though small hairline cracks are expected as normal curing occurs.
+9. Paint and stain finishes on exterior surfaces are covered for peeling or blistering for one year if the homeowner follows recommended maintenance guidelines.
+10. Flooring materials are warranted for defects in installation for one year, while structural subfloor components fall under the broader ten-year structural coverage.

--- a/doc_qa/docs/1_general_terms.txt
+++ b/doc_qa/docs/1_general_terms.txt
@@ -1,0 +1,11 @@
+General Warranty Terms
+1. Acme Homes offers a comprehensive warranty that begins on the official closing date and remains valid if homeowners follow all required maintenance guidelines.
+2. Coverage includes repair or replacement of defective materials or workmanship discovered within the first year, ensuring buyers can move in with confidence.
+3. Structural components such as the foundation, load-bearing walls, and roof framing are protected for ten years, giving long-term peace of mind to new owners.
+4. Homeowners must document any issues promptly in writing and allow Acme Homes reasonable access to make inspections or repairs during normal business hours.
+5. Normal wear and tear, damage from neglect, or problems caused by modifications outside the original plans are not covered under this warranty.
+6. Acme Homes reserves the right to use comparable materials when making repairs, and replaced items do not extend the original warranty period.
+7. The warranty cannot be transferred to a subsequent owner unless the transfer is approved in writing by Acme Homes before the sale of the property.
+8. To remain eligible for coverage, homeowners must follow seasonal maintenance guidelines provided in the owner manual, including routine checks of exterior sealants.
+9. Any disputes regarding warranty responsibilities will first be mediated through Acme Homes' designated customer service process before legal action can be considered.
+10. This warranty is designed to supplement, not replace, any manufacturer warranties that may apply to appliances, fixtures, or other installed products.

--- a/doc_qa/docs/2_indoor_coverage.txt
+++ b/doc_qa/docs/2_indoor_coverage.txt
@@ -1,0 +1,11 @@
+Indoor Warranty Coverage
+1. Walls and ceilings are protected against defects in drywall installation and paint application for one year, ensuring a smooth interior finish from day one.
+2. Built-in cabinetry, including kitchen and bathroom cabinets, will be repaired or replaced if hinges, doors, or shelves fail due to workmanship issues within the first year.
+3. Acme Homes covers interior doors and trim for warping, splitting, or improper installation so long as the homeowner does not repaint or modify the surfaces.
+4. Electrical wiring and outlets throughout the home are warranted for safe operation and compliance with building codes for a period of two years.
+5. Heating and cooling ductwork is covered for proper airflow, insulation, and connection integrity, provided filters are replaced according to manufacturer guidelines.
+6. Insulation installed in walls and attics is warranted to meet energy efficiency ratings as specified at the time of purchase, protecting homeowners from excessive heating or cooling costs.
+7. Interior plumbing behind walls, including supply lines and drain pipes, is protected for one year against leaks or faulty fittings due to installation errors.
+8. Staircases, handrails, and interior guardrails are covered for structural soundness and stability, ensuring safe movement throughout the house.
+9. Window seals and locking hardware are included in the indoor coverage to maintain energy efficiency and security against drafts or moisture intrusion.
+10. Acme Homes will address squeaking or loose subflooring discovered within the first year, provided heavy loads or alterations have not caused the issue.

--- a/doc_qa/docs/3_outdoor_coverage.txt
+++ b/doc_qa/docs/3_outdoor_coverage.txt
@@ -1,0 +1,11 @@
+Outdoor Warranty Coverage
+1. Roofing materials and installation workmanship are covered for one year, ensuring leaks caused by improper flashing or defective shingles are repaired promptly.
+2. Vinyl or fiber-cement siding is warranted against separation, warping, or material defects, provided routine cleaning and maintenance are performed by the homeowner.
+3. Gutters and downspouts are included in the coverage for secure attachment and proper water flow so long as debris buildup is removed seasonally.
+4. Exterior paint or stain on wood surfaces is covered for peeling or cracking within the first year, assuming homeowners maintain adequate drainage and ventilation around the structures.
+5. Decks, patios, and porches receive one year of protection against structural failure or installation defects that may create unsafe conditions for residents.
+6. Driveways and walkways are warranted against significant cracking or settling due to construction issues, though minor cosmetic blemishes may not qualify for repairs.
+7. Exterior light fixtures installed by Acme Homes are protected from faulty wiring or improper mounting; bulb replacement remains the homeowner's responsibility.
+8. Fences installed by the builder are covered for proper post anchoring and gate functionality, provided the homeowner does not alter the alignment.
+9. Acme Homes will correct grading or drainage issues that lead to standing water against the foundation within the first year of ownership.
+10. Landscaping, including installed shrubs and trees, is warranted for ninety days to ensure initial establishment, as long as the homeowner provides regular watering and care.

--- a/doc_qa/docs/4_fixtures.txt
+++ b/doc_qa/docs/4_fixtures.txt
@@ -1,0 +1,11 @@
+Fixtures Warranty Coverage
+1. Acme Homes warrants installed light fixtures for one year against defects in workmanship or wiring; homeowners must change bulbs as needed to maintain functionality.
+2. Faucets in kitchens, bathrooms, and laundry areas are covered against leaks or dripping caused by improper installation, provided normal cleaning practices are followed.
+3. Shower enclosures, including doors and hardware, are protected from failure or misalignment for one year, assuming no aftermarket modifications are made.
+4. Toilet fixtures and flushing mechanisms are warranted for consistent operation free from leaks or clogs that stem from installation errors rather than misuse.
+5. Built-in ventilation fans are covered for proper operation and noise levels, so long as filters are replaced and vents remain clear of obstructions.
+6. Acme Homes includes doorbell and security system wiring under this warranty to ensure adequate signal and response for the first year of ownership.
+7. Bathroom accessories such as towel bars and toilet paper holders are included, but damage caused by overloading or misuse voids coverage.
+8. The warranty for kitchen sink garbage disposals includes repair of electrical or plumbing connections, provided foreign objects are not introduced into the unit.
+9. Ceiling fans installed by the builder are covered for motor operation and secure mounting, with routine cleaning and blade balancing performed by the homeowner.
+10. If any fixture manufacturer offers a longer warranty period, Acme Homes will assist with claims during the first year, after which owners should contact manufacturers directly.

--- a/doc_qa/docs/5_plumbing.txt
+++ b/doc_qa/docs/5_plumbing.txt
@@ -1,0 +1,11 @@
+Plumbing Warranty Coverage
+1. Interior water supply pipes are warranted for one year against leaks or bursts caused by faulty fittings or poor installation practices by Acme Homes.
+2. Drainage lines are included in coverage for proper slope and secure connections to prevent backups, provided homeowners avoid flushing unsuitable materials.
+3. Water heaters installed by Acme Homes carry a one-year labor warranty in addition to any longer manufacturer coverage for the tank and heating elements.
+4. Sump pumps and associated discharge piping are protected from installation defects; routine testing is recommended to ensure these systems remain ready during storms.
+5. Bathroom and kitchen fixtures are covered for consistent water pressure and leak-free operation when used in a normal residential manner.
+6. In areas subject to freezing temperatures, outdoor hose bibs must be winterized by homeowners, as freeze damage is specifically excluded from warranty service.
+7. Gas lines installed to serve appliances or fireplaces are warranted against leaks or improper connections, contingent on annual inspection by a qualified professional.
+8. Acme Homes will address sewer line blockages discovered within the first year if they result from construction debris or incorrect grading of the pipes.
+9. Water filtration or softener systems provided by the builder are covered for installation issues, though filter replacements and routine maintenance are the homeowner's duty.
+10. The warranty does not cover clogs or damage resulting from misuse, neglect, or attempts to modify plumbing systems without prior written approval from Acme Homes.

--- a/doc_qa/docs/6_flooring.txt
+++ b/doc_qa/docs/6_flooring.txt
@@ -1,0 +1,11 @@
+Flooring Warranty Coverage
+1. Hardwood flooring is protected for one year against buckling, warping, or separation caused by improper installation; homeowners must maintain indoor humidity levels within the recommended range.
+2. Tile flooring is covered for cracks or loose tiles resulting from installation errors or defective adhesives, provided heavy impacts have not damaged the surface.
+3. Carpeted areas are warranted against seam separation and significant wrinkles for one year, so long as proper cleaning methods are followed by the homeowner.
+4. Vinyl plank or sheet flooring installed by Acme Homes is covered against curling edges or gaps due to installation faults, not wear from high traffic.
+5. Grout and caulk in tiled areas are included in coverage for adhesion issues within the first year but require routine sealing by the homeowner to remain effective.
+6. Stair treads and risers receive coverage for squeaking or shifting caused by inadequate fastening during construction, giving owners safe access between floors.
+7. Flooring transitions and baseboards are warranted against pulling away or improper alignment, provided they have not been struck by heavy objects or altered by renovations.
+8. Acme Homes will repair or replace sections damaged by adhesive failure or subfloor movement that falls under warranty guidelines.
+9. Damage from pets, spills, or harsh cleaning chemicals is excluded from coverage, so homeowners should follow manufacturer recommendations for care.
+10. Any flooring replacement due to warranty service will match the original materials and design as closely as possible but may show minor color variations due to age or availability.

--- a/doc_qa/docs/7_appliances.txt
+++ b/doc_qa/docs/7_appliances.txt
@@ -1,0 +1,11 @@
+Appliance Warranty Coverage
+1. Acme Homes provides a one-year service warranty on major appliances supplied with the home, including the refrigerator, range, dishwasher, and built-in microwave.
+2. After the first year, homeowners must contact the appliance manufacturers directly, but Acme Homes will help with documentation needed for any extended warranties.
+3. Appliances are warranted to function properly when used under normal residential conditions and maintained according to the instructions provided by each manufacturer.
+4. Installation issues such as improper gas connections or electrical wiring faults discovered within the first year will be corrected at no cost to the homeowner.
+5. Damage resulting from misuse, neglect, or attempts to repair appliances without authorization voids the warranty for that item.
+6. Appliance finishes are covered for defects at delivery, but scratches, dents, or discoloration caused by cleaning products are excluded from coverage.
+7. Range hoods and ventilation systems are included in the first-year service warranty to ensure they remove cooking odors and moisture efficiently.
+8. Water supply and drain connections for dishwashers or refrigerator ice makers are warranted against leaks due to installation errors within the first year.
+9. Homeowners must register their appliances with the manufacturers to take full advantage of extended parts coverage and recall notifications.
+10. Acme Homes recommends keeping all appliance manuals and warranty documents in a safe place to expedite service requests should issues arise after the initial year.

--- a/doc_qa/docs/8_exclusions.txt
+++ b/doc_qa/docs/8_exclusions.txt
@@ -1,0 +1,11 @@
+Warranty Exclusions
+1. Damage caused by failure to maintain the home according to Acme Homes guidelines is excluded from coverage and must be repaired at the homeowner's expense.
+2. Cosmetic items such as minor scratches, small nail pops, or slight paint variations reported after thirty days are not covered by the warranty.
+3. Acts of nature, including storms, floods, earthquakes, or other natural disasters, fall outside the scope of the warranty unless otherwise stated in writing.
+4. Problems arising from homeowner modifications or do-it-yourself projects that alter the original construction details void related portions of the warranty.
+5. Damage caused by pests or insects is excluded, so homeowners should schedule regular pest control services to protect their investment.
+6. Appliance warranties provided by manufacturers take precedence; Acme Homes does not cover failures resulting from misuse or neglect of these products.
+7. Normal wear and tear on finishes, flooring, or fixtures does not constitute a warrantable defect, though Acme Homes may offer advice on proper upkeep.
+8. Failures of systems or components that exceed the specified warranty term are excluded, even if discovered after the coverage period has expired.
+9. Secondary damage resulting from a covered issue, such as water staining from a plumbing leak, may not be covered if prompt action was not taken.
+10. Any item installed after closing by the homeowner or a third party is not covered, and resulting damage to the home will be considered outside the warranty.

--- a/doc_qa/docs/9_claim_procedure.txt
+++ b/doc_qa/docs/9_claim_procedure.txt
@@ -1,0 +1,11 @@
+Warranty Claim Procedure
+1. Homeowners should gather photos, purchase documents, and a detailed description of the issue before submitting a warranty claim to Acme Homes.
+2. Claims must be filed through the Acme Homes customer portal or by mailing a written request to the warranty department within the coverage period.
+3. Once a claim is received, a service coordinator will reach out within five business days to schedule an inspection and confirm the nature of the problem.
+4. Emergency issues involving safety or major leaks will receive priority scheduling, typically within twenty-four hours of claim submission.
+5. During the inspection, homeowners should provide access to the affected area and note any previous repairs or modifications that may be relevant.
+6. Acme Homes will determine if the issue is covered and, if so, arrange for qualified contractors or technicians to address the defect at no cost to the homeowner.
+7. If a claim is denied, homeowners will receive a written explanation outlining the reasons for denial and steps that might be taken outside the warranty.
+8. For approved claims, work orders will be generated, and homeowners will receive estimated timelines for completion along with contact information for the assigned contractor.
+9. After repairs are finished, homeowners must sign a completion statement verifying that the issue was resolved and the area restored to an acceptable condition.
+10. Homeowners who disagree with a resolution may request a second review by the warranty manager or escalate the matter according to the dispute resolution process outlined in the general terms.

--- a/doc_qa/main.py
+++ b/doc_qa/main.py
@@ -1,0 +1,102 @@
+import os
+from pathlib import Path
+from dotenv import load_dotenv
+from rich.console import Console
+from rich.prompt import Prompt
+import dspy
+
+# Ensure litellm does not attempt network calls for model cost map
+os.environ.setdefault("LITELLM_LOCAL_MODEL_COST_MAP", "True")
+
+
+class AnswerQuestion(dspy.Signature):
+    """Answer warranty questions using provided context."""
+
+    question = dspy.InputField()
+    context = dspy.InputField()
+    answer = dspy.OutputField()
+
+
+class SummarizeDoc(dspy.Signature):
+    """Summarize a document."""
+
+    document = dspy.InputField()
+    summary = dspy.OutputField(desc="one paragraph")
+
+
+class DocQAModule(dspy.Module):
+    def __init__(self, dataset):
+        super().__init__()
+        self.dataset = dataset
+        self.answer = dspy.ChainOfThought(AnswerQuestion)
+        self.summarize = dspy.Predict(SummarizeDoc)
+
+    def forward(self, question):
+        context = "\n".join(simple_retrieve(question, self.dataset))
+        return self.answer(question=question, context=context)
+
+    def summarize_document(self, index: int):
+        text = self.dataset[index]
+        return self.summarize(document=text)
+
+
+def simple_retrieve(query: str, dataset, k: int = 3):
+    words = set(query.lower().split())
+    scored = []
+    for i, text in enumerate(dataset):
+        doc_words = set(text.lower().split())
+        score = len(words & doc_words)
+        scored.append((score, i))
+    top = sorted(scored, key=lambda x: x[0], reverse=True)[:k]
+    return [dataset[i] for _, i in top]
+
+
+def load_documents():
+    docs_dir = Path(__file__).resolve().parent / "docs"
+    texts = []
+    for path in sorted(docs_dir.glob("*.txt")):
+        texts.append(path.read_text())
+    return texts
+
+
+def main():
+    load_dotenv()
+    console = Console()
+
+    api_key = os.getenv("OPENAI_API_KEY")
+    if not api_key:
+        console.print("[bold red]OPENAI_API_KEY not found in .env file.[/bold red]")
+        return
+
+    lm = dspy.LM("openai/gpt-4o-mini", api_key=api_key)
+    dspy.settings.configure(lm=lm)
+
+    dataset = load_documents()
+    module = DocQAModule(dataset)
+
+    console.print("[bold green]Acme Homes Warranty Assistant[/bold green]")
+    docs_list = "\n".join(f"{i+1}. {Path(p).name}" for i, p in enumerate(sorted((Path(__file__).parent / "docs").glob("*.txt"))))
+
+    while True:
+        action = Prompt.ask("Choose [qa] question, [sum] summarize, or [exit]")
+        if action.lower() == "exit":
+            break
+        if action.lower() == "qa":
+            q = Prompt.ask("Enter your question")
+            if not q.strip():
+                continue
+            pred = module(q)
+            console.print(f"[bold blue]A:[/bold blue] {pred.answer}")
+        elif action.lower() == "sum":
+            console.print("Documents:")
+            console.print(docs_list)
+            choice = Prompt.ask("Enter document number to summarize")
+            if not choice.isdigit() or not 1 <= int(choice) <= len(dataset):
+                console.print("Invalid choice")
+                continue
+            summary = module.summarize_document(int(choice) - 1)
+            console.print(f"[bold blue]Summary:[/bold blue] {summary.summary}")
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,10 +12,11 @@ dependencies = [
 
 [project.scripts]
 simple-math-cli = "simple_math.main:main"
+doc-qa-cli = "doc_qa.main:main"
 
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
-packages = ["simple_math"]
+packages = ["simple_math", "doc_qa"]


### PR DESCRIPTION
## Summary
- beef up each warranty doc with a title and numbered sections

## Testing
- `python -m py_compile doc_qa/main.py simple_math/main.py`
- `uv pip install -e .` *(fails: No route to host)*

------
https://chatgpt.com/codex/tasks/task_e_683b31ad176c8323aaba8547e16ef277