### PR TITLE
Add doc_qa example with gated reasoning

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,14 @@ uv run simple-math-cli
 
 You will be prompted to enter arithmetic questions, and the program will answer them using DSPy and OpenAI.
 
+### Run the `doc_qa` example
+
+```sh
+uv run doc-qa-cli
+```
+
+This example showcases gated reasoning over a provided context passage.
+
 ## Contributing More Examples
 
 - Add a new directory (e.g., `my_example/`) with an `__init__.py` and your code.

--- a/doc_qa/__init__.py
+++ b/doc_qa/__init__.py
@@ -1,0 +1,5 @@
+"""Doc QA example with gated reasoning."""
+
+from .main import main
+
+__all__ = ["main"]

--- a/doc_qa/main.py
+++ b/doc_qa/main.py
@@ -1,0 +1,75 @@
+import os
+from dotenv import load_dotenv
+import dspy
+from rich.console import Console
+from rich.prompt import Prompt
+
+
+class DocQASignature(dspy.Signature):
+    """Answer a question given a context passage."""
+
+    question = dspy.InputField()
+    context = dspy.InputField()
+    answer = dspy.OutputField()
+
+
+class ValidateAnswer(dspy.Signature):
+    """Validate an answer with yes/no."""
+
+    question = dspy.InputField()
+    context = dspy.InputField()
+    answer = dspy.InputField()
+    valid = dspy.OutputField(desc="yes or no")
+
+
+class DocQAModule(dspy.Module):
+    def __init__(self, num_steps: int = 3):
+        super().__init__()
+        self.answer = dspy.ChainOfThought(DocQASignature)
+        if hasattr(dspy, "GatedChainOfThought"):
+            self.validate = dspy.GatedChainOfThought(ValidateAnswer)
+        else:
+            self.validate = dspy.Predict(ValidateAnswer)
+        self.num_steps = num_steps
+
+    def forward(self, question: str, context: str):
+        last_prediction = None
+        for _ in range(self.num_steps):
+            prediction = self.answer(question=question, context=context)
+            last_prediction = prediction
+            check = self.validate(
+                question=question, context=context, answer=prediction.answer
+            )
+            valid_flag = str(getattr(check, "valid", "")).strip().lower()
+            if valid_flag in {"yes", "true", "1"}:
+                return prediction
+        return last_prediction
+
+
+def main():
+    load_dotenv()
+    console = Console()
+    console.print("[bold green]Doc QA Bot Initialized[/bold green]")
+
+    openai_api_key = os.getenv("OPENAI_API_KEY")
+    if not openai_api_key:
+        console.print("[bold red]Error: OPENAI_API_KEY not found in .env file.[/bold red]")
+        return
+
+    turbo = dspy.LM("openai/gpt-4o-mini", api_key=openai_api_key)
+    dspy.settings.configure(lm=turbo)
+
+    qa = DocQAModule()
+
+    context = Prompt.ask("Provide a context passage")
+    while True:
+        question = Prompt.ask("Ask a question about the context (or 'exit')")
+        if question.lower() == "exit":
+            break
+        prediction = qa(question=question, context=context)
+        console.print(f"[bold blue]Q:[/bold blue] {question}")
+        console.print(f"[bold green]A:[/bold green] {prediction.answer}")
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,10 +12,11 @@ dependencies = [
 
 [project.scripts]
 simple-math-cli = "simple_math.main:main"
+doc-qa-cli = "doc_qa.main:main"
 
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
-packages = ["simple_math"]
+packages = ["simple_math", "doc_qa"]


### PR DESCRIPTION
## Summary
- create a `doc_qa` example demonstrating gated reasoning
- implement `ValidateAnswer` and looped validation in `DocQAModule`
- register `doc_qa` entry point and package
- mention gated reasoning example in README

## Testing
- `python -m py_compile doc_qa/main.py simple_math/main.py`
- `uv pip install -e .` *(fails: No route to host)*

------
https://chatgpt.com/codex/tasks/task_e_683b3914f30483238930fdabe75a7776